### PR TITLE
Accept an arrayref as a param's value

### DIFF
--- a/lib/MetaCPAN/API/Tiny.pm
+++ b/lib/MetaCPAN/API/Tiny.pm
@@ -48,16 +48,24 @@ sub _build_extra_params {
     my %extra = @_;
     my $ua = $self->{ua};
 
-    foreach my $key (keys %extra)
+    my @params;
+    foreach my $key (sort keys %extra)
     {
         # The implementation in HTTP::Tiny uses + instead of %20, fix that
-        $extra{$key} = $ua->_uri_escape($extra{$key});
-        $extra{$key} =~ s/\+/%20/g;
+        my @values;
+        if (ref $extra{$key} eq ref []) {
+            @values = @{$extra{$key}};
+        } else {
+            @values = ($extra{$key});
+        }
+        foreach my $value (@values) {
+            $value = $ua->_uri_escape($value);
+            $value =~ s/\+/%20/g;
+            push @params, "$key=$value";
+        }
     }
 
-    my $params = join '&', map { "$_=" . $extra{$_} } sort keys %extra;
-
-    return $params;
+    return join '&', @params;
 }
 
 =method_public source

--- a/t/_build_extra_params.t
+++ b/t/_build_extra_params.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 use t::lib::Functions;
 
 my $mcpan = mcpan();
@@ -39,5 +39,12 @@ is(
     $mcpan->_build_extra_params( param1 => 'one', param2 => 'two space' ),
     'param1=one&param2=two%20space',
     'Escaping HTML in params',
+);
+
+# multiple params with the same key
+is(
+    $mcpan->_build_extra_params( param1 => ['one', 'two space'] ),
+    'param1=one&param1=two%20space',
+    'Multiple params with the same key',
 );
 


### PR DESCRIPTION
... so that we can write like this:
### /author/PERLER?join=favorite&join=release

$mcpan->fetch(
    "author/PERLER",
    join => ['favorite', 'release'],
);

https://github.com/CPAN-API/cpan-api/wiki/API-docs#joins
